### PR TITLE
FISH-7073 Reapply Payara Enterprise Branding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.glassfish.woodstock</groupId>
     <artifactId>woodstock-parent</artifactId>
-    <version>5.0.0.payara-p2-SNAPSHOT</version>
+    <version>5.0.0.payara-p2</version>
     <packaging>pom</packaging>
 
     <name>Woodstock Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.glassfish.woodstock</groupId>
     <artifactId>woodstock-parent</artifactId>
-    <version>5.0.0.payara-p1</version>
+    <version>5.0.0.payara-p2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Woodstock Parent</name>

--- a/woodstock-dt/pom.xml
+++ b/woodstock-dt/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>5.0.0.payara-p2-SNAPSHOT</version>
+        <version>5.0.0.payara-p2</version>
     </parent>
 
     <artifactId>woodstock-dt</artifactId>

--- a/woodstock-dt/pom.xml
+++ b/woodstock-dt/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>woodstock-dt</artifactId>

--- a/woodstock-example/pom.xml
+++ b/woodstock-example/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>woodstock-example</artifactId>

--- a/woodstock-example/pom.xml
+++ b/woodstock-example/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>5.0.0.payara-p2-SNAPSHOT</version>
+        <version>5.0.0.payara-p2</version>
     </parent>
 
     <artifactId>woodstock-example</artifactId>

--- a/woodstock-external/dojo/pom.xml
+++ b/woodstock-external/dojo/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.woodstock.external</groupId>
         <artifactId>woodstock-external</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>dojo</artifactId>

--- a/woodstock-external/dojo/pom.xml
+++ b/woodstock-external/dojo/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.woodstock.external</groupId>
         <artifactId>woodstock-external</artifactId>
-        <version>5.0.0.payara-p2-SNAPSHOT</version>
+        <version>5.0.0.payara-p2</version>
     </parent>
 
     <artifactId>dojo</artifactId>

--- a/woodstock-external/pom.xml
+++ b/woodstock-external/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.woodstock.external</groupId>

--- a/woodstock-external/pom.xml
+++ b/woodstock-external/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>5.0.0.payara-p2-SNAPSHOT</version>
+        <version>5.0.0.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.woodstock.external</groupId>

--- a/woodstock-webui-jsf-suntheme/pom.xml
+++ b/woodstock-webui-jsf-suntheme/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>5.0.0.payara-p2-SNAPSHOT</version>
+        <version>5.0.0.payara-p2</version>
     </parent>
 
     <artifactId>woodstock-webui-jsf-suntheme</artifactId>

--- a/woodstock-webui-jsf-suntheme/pom.xml
+++ b/woodstock-webui-jsf-suntheme/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>woodstock-webui-jsf-suntheme</artifactId>

--- a/woodstock-webui-jsf-suntheme/pom.xml
+++ b/woodstock-webui-jsf-suntheme/pom.xml
@@ -42,12 +42,16 @@
                     <include>META-INF/*</include>
                 </includes>
                 <filtering>true</filtering>
+                <excludes>
+                    <exclude>fish/payara/enterprise/images/*.png</exclude>
+                </excludes>
             </resource>
             <resource>
                 <directory>src/main/resources</directory>
                 <targetPath>com/sun/webui/jsf/suntheme</targetPath>
                 <excludes>
                     <exclude>META-INF/*</exclude>
+                    <exclude>fish/payara/enterprise/images/*.png</exclude>
                 </excludes>
             </resource>
         </resources>
@@ -63,4 +67,89 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>enterprise</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-jar</id>
+                                <configuration>
+                                    <classifier>enterprise</classifier>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>3.3.0</version>
+                        <executions>
+                            <execution>
+                                <id>use-enterprise-login-product_name_open.png</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${basedir}/target/classes/com/sun/webui/jsf/suntheme/images/other</outputDirectory>
+                                    <overwrite>true</overwrite>
+                                    <resources>
+                                        <resource>
+                                            <directory>src/main/resources/fish/payara/enterprise/images/</directory>
+                                            <includes>
+                                                <include>login-product_name_open.png</include>
+                                            </includes>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>use-enterprise-payara_logo_about.png</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${basedir}/target/classes/com/sun/webui/jsf/suntheme/images/commontaskssection/</outputDirectory>
+                                    <overwrite>true</overwrite>
+                                    <resources>
+                                        <resource>
+                                            <directory>src/main/resources/fish/payara/enterprise/images/</directory>
+                                            <includes>
+                                                <include>payara_logo_about.png</include>
+                                            </includes>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>use-enterprise-payara_logo.png</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${basedir}/target/classes/com/sun/webui/jsf/suntheme/images/commontaskssection/</outputDirectory>
+                                    <overwrite>true</overwrite>
+                                    <resources>
+                                        <resource>
+                                            <directory>src/main/resources/fish/payara/enterprise/images/</directory>
+                                            <includes>
+                                                <include>payara_logo.png</include>
+                                            </includes>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/woodstock-webui-jsf/pom.xml
+++ b/woodstock-webui-jsf/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>woodstock-webui-jsf</artifactId>

--- a/woodstock-webui-jsf/pom.xml
+++ b/woodstock-webui-jsf/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>5.0.0.payara-p2-SNAPSHOT</version>
+        <version>5.0.0.payara-p2</version>
     </parent>
 
     <artifactId>woodstock-webui-jsf</artifactId>


### PR DESCRIPTION
Updates to 5.0.0.payara-p2 and includes a Payara Enterprise profile (enterprise) which will create a woodstock-webui-jsf-suntheme with the `enterprise` classifier.