### PR TITLE
FISH-11207 Release Woodstock 6.0.1.payara-p1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.woodstock</groupId>
     <artifactId>woodstock-parent</artifactId>
-    <version>6.0.1.payara-p1</version>
+    <version>6.0.1.payara-p2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Woodstock Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.woodstock</groupId>
     <artifactId>woodstock-parent</artifactId>
-    <version>6.0.1.payara-p1-SNAPSHOT</version>
+    <version>6.0.1.payara-p1</version>
     <packaging>pom</packaging>
 
     <name>Woodstock Parent</name>

--- a/woodstock-dt/pom.xml
+++ b/woodstock-dt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1.payara-p1-SNAPSHOT</version>
+        <version>6.0.1.payara-p1</version>
     </parent>
 
     <artifactId>woodstock-dt</artifactId>

--- a/woodstock-dt/pom.xml
+++ b/woodstock-dt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1.payara-p1</version>
+        <version>6.0.1.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>woodstock-dt</artifactId>

--- a/woodstock-example/pom.xml
+++ b/woodstock-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1.payara-p1-SNAPSHOT</version>
+        <version>6.0.1.payara-p1</version>
     </parent>
 
     <artifactId>woodstock-example</artifactId>

--- a/woodstock-example/pom.xml
+++ b/woodstock-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1.payara-p1</version>
+        <version>6.0.1.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>woodstock-example</artifactId>

--- a/woodstock-external/dojo/pom.xml
+++ b/woodstock-external/dojo/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock.external</groupId>
         <artifactId>woodstock-external</artifactId>
-        <version>6.0.1.payara-p1</version>
+        <version>6.0.1.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>dojo</artifactId>

--- a/woodstock-external/dojo/pom.xml
+++ b/woodstock-external/dojo/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock.external</groupId>
         <artifactId>woodstock-external</artifactId>
-        <version>6.0.1.payara-p1-SNAPSHOT</version>
+        <version>6.0.1.payara-p1</version>
     </parent>
 
     <artifactId>dojo</artifactId>

--- a/woodstock-external/pom.xml
+++ b/woodstock-external/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1.payara-p1</version>
+        <version>6.0.1.payara-p2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.woodstock.external</groupId>

--- a/woodstock-external/pom.xml
+++ b/woodstock-external/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1.payara-p1-SNAPSHOT</version>
+        <version>6.0.1.payara-p1</version>
     </parent>
 
     <groupId>org.glassfish.woodstock.external</groupId>

--- a/woodstock-webui-jsf-suntheme/pom.xml
+++ b/woodstock-webui-jsf-suntheme/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1.payara-p1-SNAPSHOT</version>
+        <version>6.0.1.payara-p1</version>
     </parent>
 
     <artifactId>woodstock-webui-jsf-suntheme</artifactId>

--- a/woodstock-webui-jsf-suntheme/pom.xml
+++ b/woodstock-webui-jsf-suntheme/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1.payara-p1</version>
+        <version>6.0.1.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>woodstock-webui-jsf-suntheme</artifactId>

--- a/woodstock-webui-jsf/pom.xml
+++ b/woodstock-webui-jsf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1.payara-p1-SNAPSHOT</version>
+        <version>6.0.1.payara-p1</version>
     </parent>
 
     <artifactId>woodstock-webui-jsf</artifactId>

--- a/woodstock-webui-jsf/pom.xml
+++ b/woodstock-webui-jsf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1.payara-p1</version>
+        <version>6.0.1.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>woodstock-webui-jsf</artifactId>


### PR DESCRIPTION
Releases Woodstock 6.0.1 with our outstanding patches reapplied:

* 17a74495b1583f4b2c2f4c8929ee90a3bae2e9c4
* 642991e011c7327d5eb29bbddea0a86b9bad3c58
* e25579f5bbb4509e3bfc4fc6b9a9f256128f974c

Replaces https://github.com/payara/patched-src-glassfish-woodstock/pull/4